### PR TITLE
Export the Compiler as main module

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node": ">=0.8.0"
   },
   "directories": {},
-  "main": "./index.js",
+  "main": "./lib/compiler/index.js",
   "browser": "./lib/imba/browser.js",
   "webpack": "./index",
   "bin": {


### PR DESCRIPTION
Allows Node usage while retaining Browser, Webpack & BIN overrides. This means Gulp, Grunt, Fly [...etc] plugins can be made.