### PR TITLE
CLI will find index.imba, if exists within folder

### DIFF
--- a/src/compiler/cli.imba
+++ b/src/compiler/cli.imba
@@ -180,6 +180,12 @@ def ensure-dir path
 
 def sourcefile-for-path path
 	path = fspath.resolve(process.cwd, path)
+	if isDir(path)
+		var f = fspath.join(path, 'index.imba')
+		if fs.existsSync(f)
+			path = f
+		else
+			# throw error & exit here
 	SourceFile.new(path)
 
 def printCompilerError e, source: null, tok: null, tokens: null
@@ -202,7 +208,7 @@ def printCompilerError e, source: null, tok: null, tokens: null
 		if s:length < String(ln1)[:length]
 			s = ' ' + s
 		# while s:length < String(ln1)
-			
+
 		return dim[color]('    ' + s + ' |  ')
 
 


### PR DESCRIPTION
Resolves #63 

I'm familiar enough with the Error system (`printCompilerError` and `ImbaParseError`) to appropriately exit the instance. 

However, as it is, the generic/current "EISDIR: illegal operation on a directory" will be thrown.