### PR TITLE
Avoid global variables (for strict mode)

### DIFF
--- a/src/compiler/sourcemap.imba
+++ b/src/compiler/sourcemap.imba
@@ -118,10 +118,10 @@ export class SourceMap
 		# source:js += "\n//# sourceMappingURL=data:application/json;base64,{base64}"
 		return map
 
-	VLQ_SHIFT = 5
-	VLQ_CONTINUATION_BIT = 1 << VLQ_SHIFT
-	VLQ_VALUE_MASK = VLQ_CONTINUATION_BIT - 1
-	BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+	var VLQ_SHIFT = 5
+	var VLQ_CONTINUATION_BIT = 1 << VLQ_SHIFT
+	var VLQ_VALUE_MASK = VLQ_CONTINUATION_BIT - 1
+	var BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
 
 	# borrowed from CoffeeScript
 	def encodeVlq value

--- a/src/imba/dom/event-manager.imba
+++ b/src/imba/dom/event-manager.imba
@@ -1,5 +1,7 @@
 # imba$nolib=1
 
+var Imba = require("../imba")
+
 ###
 
 Manager for listening to and delegating events in Imba. A single instance

--- a/src/imba/dom/event.imba
+++ b/src/imba/dom/event.imba
@@ -1,5 +1,7 @@
 # imba$nolib=1
 
+var Imba = require("../imba")
+
 Imba.KEYMAP = {
 	"8": 'backspace'
 	"9": 'tab'

--- a/src/imba/dom/html.imba
+++ b/src/imba/dom/html.imba
@@ -1,5 +1,7 @@
 # imba$nolib=1
 
+var Imba = require("../imba")
+
 # predefine all supported html tags
 tag fragment < element
 

--- a/src/imba/dom/index.imba
+++ b/src/imba/dom/index.imba
@@ -1,3 +1,5 @@
+var Imba = require("../imba")
+
 require './manager'
 
 Imba.TagManager = Imba.TagManagerClass.new

--- a/src/imba/dom/manager.imba
+++ b/src/imba/dom/manager.imba
@@ -1,3 +1,5 @@
+var Imba = require("../imba")
+
 class Imba.TagManagerClass
 
 	prop inserts

--- a/src/imba/dom/pointer.imba
+++ b/src/imba/dom/pointer.imba
@@ -1,5 +1,7 @@
 # imba$nolib=1
 
+var Imba = require("../imba")
+
 class Imba.Pointer
 
 	prop phase

--- a/src/imba/dom/reconciler.imba
+++ b/src/imba/dom/reconciler.imba
@@ -1,5 +1,7 @@
 # imba$nolib=1
 
+var Imba = require("../imba")
+
 def removeNested root, node, caret
 	# if node/nodes isa String
 	# 	we need to use the caret to remove elements

--- a/src/imba/dom/selector.imba
+++ b/src/imba/dom/selector.imba
@@ -1,5 +1,7 @@
 # imba$nolib=1
 
+var Imba = require("../imba")
+
 unless $drop_deprecated$
 	###
 	The special syntax for selectors in Imba creates Imba.Selector
@@ -157,10 +159,10 @@ unless $drop_deprecated$
 
 
 	# def Imba.querySelectorAll
-	q$ = do |sel,scope| Imba.Selector.new(sel, scope)
+	Imba:q$ = do |sel,scope| Imba.Selector.new(sel, scope)
 
 	# def Imba.Selector.one
-	q$$ = do |sel,scope| 
+	Imba:q$$ = do |sel,scope| 
 		var el = (scope || Imba.document).querySelector(sel)
 		el && tag(el) || nil
 

--- a/src/imba/dom/server.imba
+++ b/src/imba/dom/server.imba
@@ -1,5 +1,7 @@
 # imba$nolib=1
 
+var Imba = require("../imba")
+
 # TODO classes should not be global,
 # rather imported where they are needed
 

--- a/src/imba/dom/svg.imba
+++ b/src/imba/dom/svg.imba
@@ -1,5 +1,7 @@
 # imba$nolib=1
 
+var Imba = require("../imba")
+
 tag svg:element
 
 	def self.namespaceURI

--- a/src/imba/dom/tag.imba
+++ b/src/imba/dom/tag.imba
@@ -1,6 +1,6 @@
 # imba$nolib=1
 
-extern _T
+var Imba = require("../imba")
 
 Imba.CSSKeyMap = {}
 
@@ -1158,9 +1158,9 @@ def Imba.getTagForDom dom
 	spawner ? spawner.new(dom).awaken(dom) : null
 
 # TODO drop these globals
-_T = Imba.TAGS
-id$ = Imba:getTagSingleton
-tag$wrap = Imba:getTagForDom
+var _T = Imba.TAGS
+# id$ = Imba:getTagSingleton
+# tag$wrap = Imba:getTagForDom
 
 def Imba.generateCSSPrefixes
 	var styles = window.getComputedStyle(document:documentElement, '')

--- a/src/imba/dom/touch.imba
+++ b/src/imba/dom/touch.imba
@@ -1,3 +1,5 @@
+var Imba = require("../imba")
+
 # Imba.Touch
 # Began	A finger touched the screen.
 # Moved	A finger moved on the screen.

--- a/src/imba/imba.imba
+++ b/src/imba/imba.imba
@@ -4,14 +4,7 @@
 Imba is the namespace for all runtime related utilities
 @namespace
 ###
-Imba = {VERSION: '1.0.0-rc.4'}
-
-if typeof window !== 'undefined'
-	window:imba = Imba
-	window:global ||= window
-
-	if window:define and window:define:amd
-		window.define("imba",[]) do return Imba
+var Imba = {VERSION: '1.0.0-rc.4'}
 
 ###
 True if running in client environment.

--- a/src/imba/index.imba
+++ b/src/imba/index.imba
@@ -1,15 +1,18 @@
+var Imba = require("./imba")
 
-if typeof Imba !== 'undefined'
-	console.warn "Imba v{Imba.VERSION} is already loaded."
-	module:exports = Imba
-else
-	var imba = require './imba'
-	module:exports = imba
+if typeof window !== 'undefined'
+	if window.Imba
+		console.warn "Imba v{Imba.VERSION} is already loaded."
+		Imba = window.Imba
+	else
+		window.Imba = Imba
 
-	unless $webworker$
-		require './scheduler'
-		require './dom/index'
-		
-	if $node$
-		unless $webpack$
-			require '../../register.js'
+module.exports = Imba
+
+unless $webworker$
+	require './scheduler'
+	require './dom/index'
+	
+if $node$
+	unless $webpack$
+		require '../../register.js'

--- a/src/imba/scheduler.imba
+++ b/src/imba/scheduler.imba
@@ -1,3 +1,4 @@
+var Imba = require("./imba")
 
 var requestAnimationFrame # very simple raf polyfill
 var cancelAnimationFrame


### PR DESCRIPTION
This is required for compatibility with ES6 modules and Rollup. Every
file now includes `imba.imba` and extends the Imba-object from there.

`imba/index.imba` is responsible for enforcing the "only a single
Imba-instance per window-scope"