### PR TITLE
Fix logo URL for proper link to site

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-<a href="https://imba.io" target="_blank"><img width="80" src="http://imba.io/art/logo.svg"></a>
+<a href="http://imba.io" target="_blank"><img width="80" src="http://imba.io/art/logo.svg"></a>
 
 # Imba
 


### PR DESCRIPTION
Currently the logo URL attempts to send user to `https://` version of Imba site.

This results in the following:

![](https://i.imgur.com/kwVXUAQ.png)

Just need to change `https://` to `http://`.