### PR TITLE
Fix InvalidArgumentError caused by EmptyTextNode on IE11

### DIFF
--- a/src/imba/dom/reconciler.imba
+++ b/src/imba/dom/reconciler.imba
@@ -406,7 +406,7 @@ extend tag element
 	def setText text
 		if text != @tree_
 			var val = text === null or text === false ? '' : text
-			(@text_ or @dom):textContent = val
+			(@text_ or @dom):textContent = val if (@text_ or @dom):outerHTML != undefined
 			@text_ ||= @dom:firstChild
 			@tree_ = text
 		self


### PR DESCRIPTION
From issue https://github.com/somebee/imba/issues/124